### PR TITLE
Remove Bitdeli Badge from README.md

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -158,7 +158,3 @@ It parses these lines, and aggregates stats on the most memory consuming keys, p
 	or
 
 	rdb -c memory /var/lib/redis/dump.rdb | ./redis-mem-stats.py
-
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/salimane/redis-tools/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-


### PR DESCRIPTION
Removed the Bitdeli Badge, since it is not working anymore.